### PR TITLE
'get_post_id_from_thread_id' without using request

### DIFF
--- a/threadspy/_thread.py
+++ b/threadspy/_thread.py
@@ -299,11 +299,12 @@ class ThreadsAPI:
         Returns:
             str: a post id
         """
-        thread_id = thread_id.split("?")[0]
-        thread_id = thread_id.replace("/", "")
-        post_url = f"https://www.threads.net/t/{thread_id}"
-        result = self.get_post_id_from_url(post_url=post_url)
-        return result
+        alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'
+        post_id = 0
+        for letter in thread_id:
+            post_id = (post_id * 64) + alphabet.index(letter)
+
+        return str(post_id)
 
     def get_post_id_from_url(self, post_url) -> str:
         """


### PR DESCRIPTION
## Description
This pull request updates the `get_post_id_from_thread_id` method in the codebase. The existing implementation is replaced with a new implementation that improves the efficiency and workflow of the code.

## Changes Made
- Replaced the existing code with a more optimized implementation.
- Introduced a new `alphabet` variable containing characters used for encoding.
- Implemented a loop to iterate through each character in `thread_id` and calculate the `post_id` using base64 encoding.

## Reason for Changes
The new implementation improves the performance of the `get_post_id_from_thread_id` method by utilizing base64 encoding to convert the `thread_id` into a `post_id`. This eliminates the need for string manipulation and provides a more concise and efficient solution.

## Testing Done
I have tested the updated method with various `thread_id` inputs and compared the results against the expected post ids. The tests have passed successfully, ensuring the correctness of the implementation.

## Checklist
- [x] Ran the existing test suite and ensured all tests pass.
- [x] Performed manual testing to verify the correctness of the updated method.

Please review this pull request at your convenience. Your feedback and suggestions are greatly appreciated.

Thank you.